### PR TITLE
Add missing quote to example

### DIFF
--- a/lib/Plack/App/GitHub/WebHook.pm
+++ b/lib/Plack/App/GitHub/WebHook.pm
@@ -380,7 +380,7 @@ repository into a local working directory.
     use Plack::App::GitHub::WebHook;
     use IPC::Run3;
 
-    my $branch = "master;
+    my $branch = "master";
     my $work_tree = "/some/path";
 
     Plack::App::GitHub::WebHook->new(


### PR DESCRIPTION
Missing quote around "master" in example